### PR TITLE
[#186361901] Use get_url to install MongoDB apt key.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 # vim:ft=ansible:ts=2:et:
 ---
+
 - name: Install MongoDB package key
-  ansible.builtin.apt_key:
-    id: "{{ _mongos.apt.key_id }}"
-    keyserver: "{{ _mongos.apt.key_server }}"
-    state: present
+  ansible.builtin.get_url:
+    url: "{{ _mongodb.apt.key_url }}"
+    dest: /etc/apt/trusted.gpg.d/mongodb.asc
 
 - name: Add MongoDB repository
   ansible.builtin.apt_repository:


### PR DESCRIPTION
The apt-key command has been deprecated and suggests to ‘manage keyring files in trusted.gpg.d instead’. See the Debian wiki for details. This module is kept for backwards compatiblity for systems that still use apt-key as the main way to manage apt repository keys.

See https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible