### PR TITLE
[#187284741]: Add healthcheck helper

### DIFF
--- a/files/usr/local/bin/mongos-healthcheck.sh
+++ b/files/usr/local/bin/mongos-healthcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -u
+
+if [[ $# != 1 ]]; then
+  echo "usage: $(basename "$0") <host>[:port]"
+  # sysexits(3) : EX_USAGE
+  exit 64
+fi
+
+HOST="$1"
+
+mongo --norc --quiet --tls --host "$HOST" --eval 'db.runCommand({ping: 1})' || exit 2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,3 +34,9 @@
     group: mongodb
     state: present
     shell: /usr/sbin/nologin
+
+- name: Install consul healthcheck helper
+  ansible.builtin.copy:
+    src: usr/local/bin/mongos-healthcheck.sh
+    dest: /usr/local/bin/mongos-healthcheck.sh
+    mode: "0755"


### PR DESCRIPTION
Issue https://www.mongodb.com/docs/manual/reference/command/ping/ command to given host with optional port

returns 0 (success) or 2 (failed) according to https://developer.hashicorp.com/consul/docs/services/usage/checks#script-check-exit-codes